### PR TITLE
Refine README and expand deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,37 @@
 # rtsp2jpg
 
-Expose RTSP cameras as cached JPEG snapshots backed by FastAPI + OpenCV. The service auto-detects the best available VideoCapture backend (FFmpeg or GStreamer), keeps a live worker per registered camera, and offers a lightweight HTTP API for registration, status, and snapshot retrieval.
+Expose RTSP cameras as cached JPEG snapshots backed by FastAPI + OpenCV. rtsp2jpg keeps a worker per camera, caches frames, and exposes a lightweight HTTP API for registration, status, and snapshot retrieval.
 
-```
-Camera ──▶ rtsp2jpg ──▶ Downstream consumers (YOLO, dashboards, storage)
-```
+## Why rtsp2jpg?
+- Auto-detects the best available VideoCapture backend (FFmpeg or GStreamer)
+- Ships with a modular FastAPI application (`rtsp2jpg/` package)
+- Maintains per-camera workers with SQLite persistence and health tracking
+- Configurable through environment variables or `.env`
+- Includes Docker, Docker Compose, and PM2 deployment recipes
 
-## Features
-- FastAPI application with modular architecture (`rtsp2jpg/` package)
-- Backend auto-detection between FFmpeg, GStreamer, and OpenCV default
-- Per-camera worker threads with JPEG caching and status tracking
-- SQLite persistence for registered cameras
-- Configurable via environment variables or `.env`
-- Docker image and compose stack for easy deployment
+## Quickstart
+Launch the stack with a single command:
 
-## Quick start
-
-### Python environment
-```
-python -m venv .venv
-source .venv/bin/activate
-pip install -e .[test]
-uvicorn rtsp2jpg.app:app --host 0.0.0.0 --port 8000
-```
-
-### Docker
-```
-docker build -t rtsp2jpg .
-docker run --rm -p 8000:8000 --env-file .env.example rtsp2jpg
-```
-
-For local development with FFmpeg/GStreamer dependencies pre-installed use:
-```
+```bash
 docker compose up --build
 ```
 
-Run the automated tests at any time with:
-```
-pytest
-```
+You will get a FastAPI server on `http://localhost:8000` with hot reload-friendly defaults. Use an `.env` file to provide camera credentials or overrides.
 
-## Documentation
-Detailed documentation lives under [`docs/`](docs/index.md). Start with the overview or dive into the topic you need:
+## Deployment options
+- [Local Python environment](docs/deployment.md#python-env)
+- [Docker](docs/deployment.md#docker)
+- [Docker Compose](docs/deployment.md#docker-compose)
+- [PM2](docs/deployment.md#pm2)
+- [Testing](docs/deployment.md#testing)
+
+## Learn more
+Comprehensive documentation lives in [`docs/`](docs/index.md):
 
 - [Overview](docs/overview.md)
 - [Architecture](docs/architecture.md)
 - [Configuration](docs/configuration.md)
 - [API reference](docs/api.md)
-- [Deployment guide](docs/deployment.md)
 - [Operations & monitoring](docs/operations.md)
 - [Troubleshooting](docs/troubleshooting.md)
 - [Contributing](docs/contributing.md)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,7 +2,7 @@
 
 rtsp2jpg ships with multiple deployment options. Choose the path that best matches your environment.
 
-## 1. Local Python environment
+## <a id="python-env"></a>Local Python environment
 Best for development and quick experimentation.
 
 ```bash
@@ -12,9 +12,9 @@ pip install -e .[test]
 uvicorn rtsp2jpg.app:app --host 0.0.0.0 --port 8000
 ```
 
-Use `.env` to override defaults and `pytest` to run the test suite.
+Use `.env` to override defaults and `pytest` to run the test suite. To stop the server press `Ctrl+C`.
 
-## 2. Docker
+## <a id="docker"></a>Docker
 The provided `Dockerfile` bundles Python 3.11, FFmpeg, and GStreamer plugins.
 
 ```bash
@@ -23,6 +23,7 @@ docker run --rm -p 8000:8000 --env-file .env.example rtsp2jpg
 ```
 
 Mount persistent storage if you want the SQLite database to survive restarts:
+
 ```bash
 docker run --rm -p 8000:8000 \
   -v $(pwd)/data:/data \
@@ -30,15 +31,29 @@ docker run --rm -p 8000:8000 \
   rtsp2jpg
 ```
 
-## 3. Docker Compose
+## <a id="docker-compose"></a>Docker Compose
 `docker-compose.yaml` offers a single-service stack ready to extend with dependencies (e.g., Prometheus exporters).
 
 ```bash
 docker compose up --build -d
 ```
 
-## 4. Kubernetes (example snippet)
+Stop the stack with `docker compose down`. Add services such as reverse proxies or metrics collectors to the same compose file.
+
+## <a id="pm2"></a>PM2
+Use [PM2](https://pm2.keymetrics.io/) to keep the FastAPI server alive on bare-metal or VM deployments.
+
+```bash
+pip install -e .
+pm2 start uvicorn --name rtsp2jpg -- \
+  rtsp2jpg.app:app --host 0.0.0.0 --port 8000
+```
+
+Optional: enable restarts on boot with `pm2 save` and `pm2 startup`. PM2's log aggregation provides quick visibility into worker health.
+
+## Kubernetes (example snippet)
 Minimal Deployment + Service example:
+
 ```yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -82,8 +97,9 @@ spec:
       targetPort: 8000
 ```
 
-## 5. Reverse proxy
+## Reverse proxy
 Place Nginx, Traefik, or Caddy in front to add TLS, authentication, or rate limiting. Example Nginx location block:
+
 ```nginx
 location /rtsp2jpg/ {
     proxy_pass http://rtsp2jpg:8000/;
@@ -92,8 +108,15 @@ location /rtsp2jpg/ {
 }
 ```
 
-## 6. Observability
+## Observability
 - Add metrics or logs by tailing stdout (`docker logs`) or shipping JSON logs from the container.
 - Expose Prometheus or OpenTelemetry metrics by integrating additional middleware (not shipped by default).
 
 Refer to the [Operations guide](operations.md) for runtime maintenance and tuning.
+
+## <a id="testing"></a>Testing
+Run the automated tests to validate your deployment:
+
+```bash
+pytest
+```


### PR DESCRIPTION
## Summary
- streamline the README to focus on positioning, a one-command quickstart, and documentation entry points
- add anchored deployment sections for Python, Docker, Docker Compose, PM2, and testing references in the deployment guide
- document PM2 usage and clarify docker compose guidance while keeping extended details in docs

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_e_68df387acfc083289c0672e73460df4a