### PR TITLE
Clarify Docker hot reload behavior in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,18 @@ docker build -t rtsp2jpg .
 docker run --rm -p 8000:8000 --env-file .env.example rtsp2jpg
 ```
 
+The published image starts a plain `uvicorn` process without `--reload`. To
+develop with live reload you can mount your source tree as a volume and add the
+flag, for example:
+
+```
+docker run --rm -p 8000:8000 \
+  -v "$(pwd)":/app \
+  --env-file .env.example \
+  rtsp2jpg \
+  uvicorn rtsp2jpg.app:app --host 0.0.0.0 --port 8000 --reload
+```
+
 For local development with FFmpeg/GStreamer dependencies pre-installed use:
 ```
 docker compose up --build


### PR DESCRIPTION
## Summary
- explain that the Docker image runs uvicorn without --reload
- document how to enable live reload by mounting the source and adding the flag

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df3f4102708328b99abf31a012a63d