### PR TITLE
Clarify README guidance on .env usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ For local development with FFmpeg/GStreamer dependencies pre-installed use:
 docker compose up --build
 ```
 
+The `.env` file is for service configuration knobs—database path, logging level, throttling, and similar options.
+Supply RTSP URLs (with credentials) via the `/register` API or follow the [overview quick start](docs/overview.md#quick-start).
+
 Run the automated tests at any time with:
 ```
 pytest


### PR DESCRIPTION
## Summary
- update the quick start instructions to explain `.env` is for service configuration knobs
- direct users to the `/register` API or overview quick start for providing RTSP URLs with credentials

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df3f414a8c8328bbbb84ff32aa72d7