### PR TITLE
Restore camera workers after service restart

### DIFF
--- a/rtsp2jpg/db.py
+++ b/rtsp2jpg/db.py
@@ -6,7 +6,7 @@ import sqlite3
 import threading
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Iterator, Optional
+from typing import Iterator, List, Optional
 
 from .config import get_settings
 
@@ -74,3 +74,9 @@ def delete_camera(token: str) -> None:
     with _DB_LOCK, _connection() as conn:
         conn.execute("DELETE FROM cameras WHERE token = ?", (token,))
         conn.commit()
+
+
+def list_cameras() -> List[Camera]:
+    with _DB_LOCK, _connection() as conn:
+        rows = conn.execute("SELECT token, rtsp_url, status FROM cameras").fetchall()
+    return [Camera(*row) for row in rows]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -240,9 +240,16 @@ def test_app_lifespan_triggers_cleanup(tmp_path, monkeypatch):
     clear_called = []
     init_called = []
 
-    monkeypatch.setattr(app_module, "stop_all_workers", lambda: stop_called.append(True))
+    monkeypatch.setattr(app_module.worker, "stop_all_workers", lambda: stop_called.append(True))
     monkeypatch.setattr(app_module.cache, "clear_all", lambda: clear_called.append(True))
-    monkeypatch.setattr(app_module, "init_db", lambda: init_called.append(True))
+
+    original_init_db = app_module.db.init_db
+
+    def _init_wrapper():
+        init_called.append(True)
+        original_init_db()
+
+    monkeypatch.setattr(app_module.db, "init_db", _init_wrapper)
 
     app = app_module.create_app()
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,81 @@
+import importlib
+
+from fastapi.testclient import TestClient
+
+from rtsp2jpg import cache, config, db, worker
+
+
+def _reload_app():
+    return importlib.reload(importlib.import_module("rtsp2jpg.app"))
+
+
+def test_lifespan_restores_registered_cameras(tmp_path, monkeypatch):
+    db_file = tmp_path / "restore.db"
+    monkeypatch.setenv("RTSP2JPG_DB_PATH", str(db_file))
+    config.get_settings.cache_clear()
+    cache.clear_all()
+
+    db.init_db()
+    token = "tok123"
+    rtsp_url = "rtsp://example/stream"
+    db.add_camera(token, rtsp_url, status="inactive")
+
+    start_calls = []
+
+    def fake_start(token_arg, url_arg, backend_flag):
+        start_calls.append((token_arg, url_arg, backend_flag))
+
+    monkeypatch.setattr(worker, "start_worker", fake_start)
+    monkeypatch.setattr(worker, "stop_all_workers", lambda: None)
+    original_clear_all = cache.clear_all
+    monkeypatch.setattr(cache, "clear_all", lambda: None)
+
+    app_module = _reload_app()
+    monkeypatch.setattr(app_module, "choose_backend", lambda url, prefer=None: (42, "ffmpeg"))
+
+    with TestClient(app_module.app, raise_server_exceptions=False):
+        pass
+
+    assert start_calls == [(token, rtsp_url, 42)]
+
+    original_clear_all()
+    config.get_settings.cache_clear()
+
+
+def test_lifespan_marks_error_when_backend_unavailable(tmp_path, monkeypatch):
+    db_file = tmp_path / "error.db"
+    monkeypatch.setenv("RTSP2JPG_DB_PATH", str(db_file))
+    config.get_settings.cache_clear()
+    cache.clear_all()
+
+    db.init_db()
+    token = "tok456"
+    rtsp_url = "rtsp://example/error"
+    db.add_camera(token, rtsp_url, status="inactive")
+
+    monkeypatch.setattr(worker, "start_worker", lambda *args, **kwargs: None)
+    monkeypatch.setattr(worker, "stop_all_workers", lambda: None)
+    original_clear_all = cache.clear_all
+    monkeypatch.setattr(cache, "clear_all", lambda: None)
+
+    app_module = _reload_app()
+
+    def _raise(*_args, **_kwargs):
+        raise ValueError("boom")
+
+    monkeypatch.setattr(app_module, "choose_backend", _raise)
+
+    with TestClient(app_module.app, raise_server_exceptions=False):
+        pass
+
+    status = cache.get_status(token)
+    assert status["status"] == "error"
+    assert status["error"] == "boom"
+
+    camera = db.get_camera(token)
+    assert camera is not None
+    assert camera.status == "error"
+
+    original_clear_all()
+    cache.clear(token)
+    config.get_settings.cache_clear()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -16,11 +16,15 @@ def test_db_crud(tmp_path, monkeypatch):
     assert camera.rtsp_url == rtsp_url
     assert camera.status == "active"
 
+    cameras = db.list_cameras()
+    assert cameras == [camera]
+
     db.update_status(token, "inactive")
     camera = db.get_camera(token)
     assert camera.status == "inactive"
 
     db.delete_camera(token)
     assert db.get_camera(token) is None
+    assert db.list_cameras() == []
 
     config.get_settings.cache_clear()


### PR DESCRIPTION
## Summary
- add a database helper to list stored cameras
- restart camera workers during application startup and record backend selection failures
- add regression coverage for the new startup behaviour

## Testing
- pytest