### PR TITLE
Monitor decoder warnings and skip corrupted frames

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
   "opencv-python-headless>=4.10",
   "numpy>=1.26",
   "pydantic-settings>=2.3",
+  "httpx>=0.27",
 ]
 
 [project.urls]

--- a/rtsp2jpg/config.py
+++ b/rtsp2jpg/config.py
@@ -19,6 +19,14 @@ class Settings(BaseSettings):
     ffmpeg_first: bool = Field(default=True, description="Prefer FFmpeg backend when available")
     jpeg_quality: int = Field(default=85, description="JPEG quality for encoded snapshots")
     log_level: str = Field(default="INFO", description="Base logging level")
+    decoder_warning_window_sec: float = Field(
+        default=0.4,
+        description="Duration to treat decoder warnings as affecting subsequent frames",
+    )
+    enable_decoder_log_monitor: bool = Field(
+        default=True,
+        description="Capture FFmpeg/GStreamer stderr to detect decode corruption",
+    )
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/rtsp2jpg/decoder_warnings.py
+++ b/rtsp2jpg/decoder_warnings.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import threading
 import time
-from typing import Optional
+from typing import Dict, Optional, Set
+from urllib.parse import urlparse
 
 from .config import get_settings
 
@@ -28,11 +30,22 @@ class _DecoderWarningMonitor:
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
-        self._last_warning: float = 0.0
+        self._last_warning_global: float = 0.0
+        self._last_warning_by_token: Dict[str, float] = {}
+        self._pointer_by_token: Dict[str, Set[str]] = {}
+        self._token_by_pointer: Dict[str, str] = {}
+        self._keywords_by_token: Dict[str, Set[str]] = {}
         self._enabled = False
         self._reader_thread: Optional[threading.Thread] = None
         self._pipe_r: Optional[int] = None
         self._orig_stderr_fd: Optional[int] = None
+
+    @staticmethod
+    def _extract_pointer(line: str) -> Optional[str]:
+        match = re.search(r"\[[^\[]*?@\s*(0x[0-9a-fA-F]+)\]", line)
+        if match:
+            return match.group(1).casefold()
+        return None
 
     def start(self) -> None:
         if self._enabled:
@@ -99,28 +112,84 @@ class _DecoderWarningMonitor:
             self._handle_line(line.decode("utf-8", "replace"))
         return buffer
 
-    def _handle_line(self, line: str) -> None:
-        line = line.strip()
+    def _handle_line(self, raw_line: str) -> None:
+        line = raw_line.strip()
         if not line:
             return
         folded = line.casefold()
-        if any(pattern in folded for pattern in _WARNING_PATTERNS):
-            with self._lock:
-                self._last_warning = time.monotonic()
-            LOGGER.debug("Decoder reported warning: %s", line)
+
+        pointer = self._extract_pointer(line)
+        token = None
+        with self._lock:
+            if pointer and pointer in self._token_by_pointer:
+                token = self._token_by_pointer[pointer]
+            else:
+                token = self._detect_token_for_line(folded)
+                if token and pointer:
+                    self._token_by_pointer[pointer] = token
+                    self._pointer_by_token.setdefault(token, set()).add(pointer)
+
+            if token is None and any(pattern in folded for pattern in _WARNING_PATTERNS):
+                # Track a global warning fallback so callers can still consult it.
+                self._last_warning_global = time.monotonic()
+                LOGGER.debug("Decoder reported warning (unattributed): %s", line)
+                return
+
+            if token and any(pattern in folded for pattern in _WARNING_PATTERNS):
+                now = time.monotonic()
+                self._last_warning_by_token[token] = now
+                self._last_warning_global = now
+                LOGGER.debug("Decoder reported warning for %s: %s", token, line)
 
     def record_manual_warning(self) -> None:
         with self._lock:
-            self._last_warning = time.monotonic()
+            self._last_warning_global = time.monotonic()
 
     def had_recent_warning(self, window_sec: float) -> bool:
         if not self._enabled and os.name == "posix":
             # Monitoring might be disabled by configuration; treat as no warning.
             pass
         with self._lock:
-            if not self._last_warning:
+            if not self._last_warning_global:
                 return False
-            return (time.monotonic() - self._last_warning) <= window_sec
+            return (time.monotonic() - self._last_warning_global) <= window_sec
+
+    def register_stream(self, token: str, url: str) -> None:
+        keywords = _keywords_for_url(url)
+        with self._lock:
+            self._keywords_by_token[token] = keywords
+            # Clear any existing warning state/pointer mapping for reused tokens.
+            for pointer in self._pointer_by_token.pop(token, set()):
+                self._token_by_pointer.pop(pointer, None)
+            self._last_warning_by_token.pop(token, None)
+
+    def unregister_stream(self, token: str) -> None:
+        with self._lock:
+            self._keywords_by_token.pop(token, None)
+            for pointer in self._pointer_by_token.pop(token, set()):
+                self._token_by_pointer.pop(pointer, None)
+            self._last_warning_by_token.pop(token, None)
+
+    def had_recent_warning_for_token(self, token: str, window_sec: float) -> bool:
+        if not self._enabled and os.name == "posix":
+            pass
+        with self._lock:
+            timestamp = self._last_warning_by_token.get(token)
+            if not timestamp:
+                return False
+            return (time.monotonic() - timestamp) <= window_sec
+
+    def record_manual_warning_for_token(self, token: str) -> None:
+        with self._lock:
+            now = time.monotonic()
+            self._last_warning_by_token[token] = now
+            self._last_warning_global = max(self._last_warning_global, now)
+
+    def _detect_token_for_line(self, folded_line: str) -> Optional[str]:
+        for token, keywords in self._keywords_by_token.items():
+            if any(keyword and keyword in folded_line for keyword in keywords):
+                return token
+        return None
 
 
 _MONITOR: Optional[_DecoderWarningMonitor] = None
@@ -155,3 +224,48 @@ def had_recent_warning(window_sec: float) -> bool:
 def record_manual_warning() -> None:
     monitor = _get_monitor()
     monitor.record_manual_warning()
+
+
+def register_stream(token: str, url: str) -> None:
+    settings = get_settings()
+    if not settings.enable_decoder_log_monitor:
+        return
+    monitor = _get_monitor()
+    monitor.register_stream(token, url)
+
+
+def unregister_stream(token: str) -> None:
+    settings = get_settings()
+    if not settings.enable_decoder_log_monitor:
+        return
+    monitor = _get_monitor()
+    monitor.unregister_stream(token)
+
+
+def had_recent_warning_for_token(token: str, window_sec: float) -> bool:
+    settings = get_settings()
+    if not settings.enable_decoder_log_monitor:
+        return False
+    monitor = _get_monitor()
+    return monitor.had_recent_warning_for_token(token, window_sec)
+
+
+def record_manual_warning_for_token(token: str) -> None:
+    settings = get_settings()
+    if not settings.enable_decoder_log_monitor:
+        return
+    monitor = _get_monitor()
+    monitor.record_manual_warning_for_token(token)
+
+
+def _keywords_for_url(url: str) -> Set[str]:
+    parsed = urlparse(url)
+    keywords: Set[str] = set()
+    if parsed.hostname:
+        keywords.add(parsed.hostname.casefold())
+    if parsed.port:
+        keywords.add(str(parsed.port))
+    if parsed.path and parsed.path != "/":
+        keywords.add(parsed.path.casefold())
+        keywords.add(parsed.path.strip("/").casefold())
+    return {word for word in keywords if word}

--- a/rtsp2jpg/decoder_warnings.py
+++ b/rtsp2jpg/decoder_warnings.py
@@ -1,0 +1,157 @@
+"""Helpers for detecting decoder corruption warnings from FFmpeg/GStreamer."""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from typing import Optional
+
+from .config import get_settings
+
+LOGGER = logging.getLogger(__name__)
+
+_WARNING_PATTERNS = (
+    "error while decoding",
+    "cabac decode",
+    "co located pocs unavailable",
+    "concealing",
+    "corrupt input",
+    "corrupt macroblock",
+    "error received from element",
+)
+
+
+class _DecoderWarningMonitor:
+    """Capture stderr output and mark when decoder corruption is reported."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._last_warning: float = 0.0
+        self._enabled = False
+        self._reader_thread: Optional[threading.Thread] = None
+        self._pipe_r: Optional[int] = None
+        self._orig_stderr_fd: Optional[int] = None
+
+    def start(self) -> None:
+        if self._enabled:
+            return
+
+        if os.name != "posix":
+            LOGGER.debug("Decoder warning monitor not supported on %s", os.name)
+            return
+
+        try:
+            pipe_r, pipe_w = os.pipe()
+            orig_stderr_fd = os.dup(2)
+            os.dup2(pipe_w, 2)
+            os.close(pipe_w)
+        except OSError as exc:
+            LOGGER.warning("Decoder warning monitor disabled: %s", exc)
+            return
+
+        self._pipe_r = pipe_r
+        self._orig_stderr_fd = orig_stderr_fd
+        self._enabled = True
+        self._reader_thread = threading.Thread(target=self._pump_stderr, name="decoder-log", daemon=True)
+        self._reader_thread.start()
+        LOGGER.debug("Decoder warning monitor started")
+
+    def _pump_stderr(self) -> None:
+        assert self._pipe_r is not None
+        assert self._orig_stderr_fd is not None
+
+        buffer = b""
+        while True:
+            try:
+                chunk = os.read(self._pipe_r, 4096)
+            except OSError as exc:  # pragma: no cover - defensive
+                LOGGER.debug("Decoder warning monitor read failed: %s", exc)
+                break
+            if not chunk:
+                break
+            try:
+                os.write(self._orig_stderr_fd, chunk)
+            except OSError:  # pragma: no cover - write best effort
+                pass
+            buffer += chunk
+            buffer = self._process_buffer(buffer)
+
+        if buffer:
+            try:
+                os.write(self._orig_stderr_fd, buffer)
+            except OSError:  # pragma: no cover - best effort
+                pass
+
+        try:
+            os.close(self._pipe_r)
+        except OSError:  # pragma: no cover - best effort cleanup
+            pass
+        try:
+            os.close(self._orig_stderr_fd)
+        except OSError:  # pragma: no cover - best effort cleanup
+            pass
+
+    def _process_buffer(self, buffer: bytes) -> bytes:
+        while b"\n" in buffer:
+            line, buffer = buffer.split(b"\n", 1)
+            self._handle_line(line.decode("utf-8", "replace"))
+        return buffer
+
+    def _handle_line(self, line: str) -> None:
+        line = line.strip()
+        if not line:
+            return
+        folded = line.casefold()
+        if any(pattern in folded for pattern in _WARNING_PATTERNS):
+            with self._lock:
+                self._last_warning = time.monotonic()
+            LOGGER.debug("Decoder reported warning: %s", line)
+
+    def record_manual_warning(self) -> None:
+        with self._lock:
+            self._last_warning = time.monotonic()
+
+    def had_recent_warning(self, window_sec: float) -> bool:
+        if not self._enabled and os.name == "posix":
+            # Monitoring might be disabled by configuration; treat as no warning.
+            pass
+        with self._lock:
+            if not self._last_warning:
+                return False
+            return (time.monotonic() - self._last_warning) <= window_sec
+
+
+_MONITOR: Optional[_DecoderWarningMonitor] = None
+_MONITOR_LOCK = threading.Lock()
+
+
+def _get_monitor() -> _DecoderWarningMonitor:
+    global _MONITOR
+    if _MONITOR is None:
+        with _MONITOR_LOCK:
+            if _MONITOR is None:
+                _MONITOR = _DecoderWarningMonitor()
+    return _MONITOR
+
+
+def ensure_started() -> None:
+    settings = get_settings()
+    if not settings.enable_decoder_log_monitor:
+        return
+    monitor = _get_monitor()
+    monitor.start()
+
+
+def had_recent_warning(window_sec: float) -> bool:
+    settings = get_settings()
+    if not settings.enable_decoder_log_monitor:
+        return False
+    monitor = _get_monitor()
+    return monitor.had_recent_warning(window_sec)
+
+
+def record_manual_warning() -> None:
+    monitor = _get_monitor()
+    monitor.record_manual_warning()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -44,7 +44,11 @@ def test_worker_skips_invalid_frames_before_caching(monkeypatch):
     monkeypatch.setattr(worker, "get_settings", lambda: _DummySettings())
     monkeypatch.setattr(worker, "update_status", lambda *args, **kwargs: None)
     monkeypatch.setattr(worker, "ensure_decoder_monitor_started", lambda: None)
-    monkeypatch.setattr(worker, "decoder_warning_recent", lambda window: False)
+    monkeypatch.setattr(worker, "register_decoder_stream", lambda *args, **kwargs: None)
+    monkeypatch.setattr(worker, "unregister_decoder_stream", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        worker, "decoder_warning_recent_for_token", lambda *args, **kwargs: False
+    )
     monkeypatch.setattr(worker, "MAX_CONSECUTIVE_FRAME_FAILURES", 2, raising=False)
 
     statuses = []
@@ -96,7 +100,11 @@ def test_worker_reconnects_after_excessive_invalid_frames(monkeypatch):
     monkeypatch.setattr(worker, "get_settings", lambda: _DummySettings())
     monkeypatch.setattr(worker, "update_status", lambda *args, **kwargs: None)
     monkeypatch.setattr(worker, "ensure_decoder_monitor_started", lambda: None)
-    monkeypatch.setattr(worker, "decoder_warning_recent", lambda window: False)
+    monkeypatch.setattr(worker, "register_decoder_stream", lambda *args, **kwargs: None)
+    monkeypatch.setattr(worker, "unregister_decoder_stream", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        worker, "decoder_warning_recent_for_token", lambda *args, **kwargs: False
+    )
     monkeypatch.setattr(worker, "MAX_CONSECUTIVE_FRAME_FAILURES", 2, raising=False)
 
     statuses = []
@@ -129,13 +137,15 @@ def test_worker_skips_frames_when_decoder_reports_warning(monkeypatch):
     monkeypatch.setattr(worker, "get_settings", lambda: _DummySettings())
     monkeypatch.setattr(worker, "update_status", lambda *args, **kwargs: None)
     monkeypatch.setattr(worker, "ensure_decoder_monitor_started", lambda: None)
+    monkeypatch.setattr(worker, "register_decoder_stream", lambda *args, **kwargs: None)
+    monkeypatch.setattr(worker, "unregister_decoder_stream", lambda *args, **kwargs: None)
 
     skip_next = iter([True, False])
 
-    def fake_warning(window: float) -> bool:
+    def fake_warning(*args, **kwargs) -> bool:
         return next(skip_next, False)
 
-    monkeypatch.setattr(worker, "decoder_warning_recent", fake_warning)
+    monkeypatch.setattr(worker, "decoder_warning_recent_for_token", fake_warning)
 
     stored_frames = []
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -14,6 +14,7 @@ class _DummySettings:
     read_throttle_sec = 0.0
     reconnect_delay_sec = 0.0
     jpeg_quality = 75
+    decoder_warning_window_sec = 0.2
 
 
 class _FakeCapture:
@@ -42,6 +43,8 @@ def test_worker_skips_invalid_frames_before_caching(monkeypatch):
     monkeypatch.setattr(worker, "open_stream", lambda url, flag: (fake_capture, "ok"))
     monkeypatch.setattr(worker, "get_settings", lambda: _DummySettings())
     monkeypatch.setattr(worker, "update_status", lambda *args, **kwargs: None)
+    monkeypatch.setattr(worker, "ensure_decoder_monitor_started", lambda: None)
+    monkeypatch.setattr(worker, "decoder_warning_recent", lambda window: False)
     monkeypatch.setattr(worker, "MAX_CONSECUTIVE_FRAME_FAILURES", 2, raising=False)
 
     statuses = []
@@ -92,6 +95,8 @@ def test_worker_reconnects_after_excessive_invalid_frames(monkeypatch):
     monkeypatch.setattr(worker, "open_stream", lambda url, flag: (fake_capture, "ok"))
     monkeypatch.setattr(worker, "get_settings", lambda: _DummySettings())
     monkeypatch.setattr(worker, "update_status", lambda *args, **kwargs: None)
+    monkeypatch.setattr(worker, "ensure_decoder_monitor_started", lambda: None)
+    monkeypatch.setattr(worker, "decoder_warning_recent", lambda window: False)
     monkeypatch.setattr(worker, "MAX_CONSECUTIVE_FRAME_FAILURES", 2, raising=False)
 
     statuses = []
@@ -110,3 +115,37 @@ def test_worker_reconnects_after_excessive_invalid_frames(monkeypatch):
 
     assert "connecting" in statuses
     assert stored_frames == []
+
+
+def test_worker_skips_frames_when_decoder_reports_warning(monkeypatch):
+    token = "cam-warn"
+    cache.clear(token)
+
+    stop_event = threading.Event()
+    valid_frame = np.ones((3, 3, 3), dtype=np.uint8)
+    fake_capture = _FakeCapture([(True, valid_frame), (True, valid_frame * 2)], stop_event)
+
+    monkeypatch.setattr(worker, "open_stream", lambda url, flag: (fake_capture, "ok"))
+    monkeypatch.setattr(worker, "get_settings", lambda: _DummySettings())
+    monkeypatch.setattr(worker, "update_status", lambda *args, **kwargs: None)
+    monkeypatch.setattr(worker, "ensure_decoder_monitor_started", lambda: None)
+
+    skip_next = iter([True, False])
+
+    def fake_warning(window: float) -> bool:
+        return next(skip_next, False)
+
+    monkeypatch.setattr(worker, "decoder_warning_recent", fake_warning)
+
+    stored_frames = []
+
+    def tracked_store_frame(token_arg, frame, quality):
+        stored_frames.append(frame.copy())
+        stop_event.set()
+
+    monkeypatch.setattr(worker.cache, "store_frame", tracked_store_frame)
+
+    worker._camera_worker(token, "rtsp://example", stop_event)
+
+    assert len(stored_frames) == 1
+    np.testing.assert_array_equal(stored_frames[0], valid_frame * 2)


### PR DESCRIPTION
## Summary
- add a decoder warning monitor that captures FFmpeg/GStreamer stderr and records corruption signals
- expose configuration for the warning window and log monitor, wiring the worker to skip frames flagged by decoder warnings
- document the behaviour in the troubleshooting guide and expand worker tests to cover warning-driven skips

## Testing
- pytest