### PR TITLE
Add per-request JPEG quality overrides for snapshots

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -72,6 +72,11 @@ Retrieve runtime state for a camera.
 ## `GET /snapshot/{token}`
 Return the most recent JPEG frame as binary payload.
 
+Query parameters:
+
+- `q` *(optional, int, default `100`)* — JPEG quality to use when encoding the
+  snapshot (1–100). Lower values reduce file size at the cost of image quality.
+
 **Success 200**
 - Content-Type: `image/jpeg`
 - Body: JPEG bytes

--- a/rtsp2jpg/api/snapshot.py
+++ b/rtsp2jpg/api/snapshot.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import Response
 
 from .. import cache
@@ -11,8 +11,9 @@ router = APIRouter(tags=["snapshot"])
 
 
 @router.get("/snapshot/{token}")
-def snapshot(token: str) -> Response:
-    jpeg = cache.get_jpeg(token)
+def snapshot(token: str, q: int = Query(default=100, ge=1, le=100)) -> Response:
+    quality = None if q == 100 else q
+    jpeg = cache.get_jpeg(token, quality=quality)
     if not jpeg:
         raise HTTPException(status_code=503, detail="No frame available yet")
     return Response(content=jpeg, media_type="image/jpeg")

--- a/rtsp2jpg/api/snapshot.py
+++ b/rtsp2jpg/api/snapshot.py
@@ -12,8 +12,7 @@ router = APIRouter(tags=["snapshot"])
 
 @router.get("/snapshot/{token}")
 def snapshot(token: str, q: int = Query(default=100, ge=1, le=100)) -> Response:
-    quality = None if q == 100 else q
-    jpeg = cache.get_jpeg(token, quality=quality)
+    jpeg = cache.get_jpeg(token, quality=q)
     if not jpeg:
         raise HTTPException(status_code=503, detail="No frame available yet")
     return Response(content=jpeg, media_type="image/jpeg")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,5 @@
 import importlib
-from typing import List
+from typing import List, Optional
 
 import pytest
 from fastapi.testclient import TestClient
@@ -82,12 +82,39 @@ def test_snapshot_success(client: TestClient, monkeypatch):
     response = client.post("/register", json={"rtsp_url": "rtsp://example"})
     token = response.json()["token"]
 
-    monkeypatch.setattr(cache, "get_jpeg", lambda _token: b"jpeg" if _token == token else None)
+    qualities: List[Optional[int]] = []
+
+    def fake_get_jpeg(_token: str, quality: Optional[int] = None) -> Optional[bytes]:
+        qualities.append(quality)
+        return b"jpeg" if _token == token else None
+
+    monkeypatch.setattr(cache, "get_jpeg", fake_get_jpeg)
 
     snapshot = client.get(f"/snapshot/{token}")
     assert snapshot.status_code == 200
     assert snapshot.content == b"jpeg"
     assert snapshot.headers["content-type"] == "image/jpeg"
+    assert qualities == [None]
+
+
+def test_snapshot_allows_quality_override(client: TestClient, monkeypatch):
+    monkeypatch.setattr(cameras, "choose_backend", lambda url, prefer=None: (None, "default"))
+    response = client.post("/register", json={"rtsp_url": "rtsp://example"})
+    token = response.json()["token"]
+
+    qualities: List[Optional[int]] = []
+
+    def fake_get_jpeg(_token: str, quality: Optional[int] = None) -> Optional[bytes]:
+        qualities.append(quality)
+        return b"jpeg" if _token == token else None
+
+    monkeypatch.setattr(cache, "get_jpeg", fake_get_jpeg)
+
+    snapshot = client.get(f"/snapshot/{token}?q=25")
+    assert snapshot.status_code == 200
+    assert snapshot.content == b"jpeg"
+    assert snapshot.headers["content-type"] == "image/jpeg"
+    assert qualities == [25]
 
 
 def test_status_reflects_cache_error(client: TestClient, monkeypatch):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -94,7 +94,7 @@ def test_snapshot_success(client: TestClient, monkeypatch):
     assert snapshot.status_code == 200
     assert snapshot.content == b"jpeg"
     assert snapshot.headers["content-type"] == "image/jpeg"
-    assert qualities == [None]
+    assert qualities == [100]
 
 
 def test_snapshot_allows_quality_override(client: TestClient, monkeypatch):
@@ -115,6 +115,26 @@ def test_snapshot_allows_quality_override(client: TestClient, monkeypatch):
     assert snapshot.content == b"jpeg"
     assert snapshot.headers["content-type"] == "image/jpeg"
     assert qualities == [25]
+
+
+def test_snapshot_allows_requesting_full_quality(client: TestClient, monkeypatch):
+    monkeypatch.setattr(cameras, "choose_backend", lambda url, prefer=None: (None, "default"))
+    response = client.post("/register", json={"rtsp_url": "rtsp://example"})
+    token = response.json()["token"]
+
+    qualities: List[Optional[int]] = []
+
+    def fake_get_jpeg(_token: str, quality: Optional[int] = None) -> Optional[bytes]:
+        qualities.append(quality)
+        return b"jpeg" if _token == token else None
+
+    monkeypatch.setattr(cache, "get_jpeg", fake_get_jpeg)
+
+    snapshot = client.get(f"/snapshot/{token}?q=100")
+    assert snapshot.status_code == 200
+    assert snapshot.content == b"jpeg"
+    assert snapshot.headers["content-type"] == "image/jpeg"
+    assert qualities == [100]
 
 
 def test_status_reflects_cache_error(client: TestClient, monkeypatch):


### PR DESCRIPTION
## Summary
- allow clients to request snapshots with a configurable JPEG quality parameter
- update caching to remember the original quality and re-encode frames on demand
- document the new query parameter in the snapshot endpoint reference

## Testing
- pytest